### PR TITLE
Hardening: multi-stage Docker build + .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+# Dependencies (reinstalled inside the build stage)
+node_modules
+
+# Build output (regenerated inside the build stage)
+dist
+
+# Version control
+.git
+.gitignore
+
+# Docs, tests, and source design assets — not needed to build or serve
+docs
+test
+*.psd
+*.ai
+
+# Editor / OS cruft
+.DS_Store
+.vscode
+.idea
+
+# Env / secrets
+.env
+.env.*
+*.local
+
+# Docker files themselves
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,13 @@
-FROM nginx
+# syntax=docker/dockerfile:1
 
-COPY . /usr/share/nginx/html
+# Stage 1: build the Vite app
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Stage 2: serve only the built static assets with nginx
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -2,10 +2,5 @@ import { Game } from "./game.js";
 
 (function() {
   const game = new Game();
-  window.game = game;
-  window.welcome_scene = game.scenes["welcome"];
-  window.stage_scene = game.scenes["stage"];
-  window.battle_field_scene = game.scenes["battle_field"];
-  window.report_scene = game.scenes["report"];
   return game.kick_off();
 }());


### PR DESCRIPTION
## Summary

Two low/informational security-hardening improvements for this client-side Vite game.

### 1. [LOW] Dockerfile shipped the entire repo to the nginx web root

The previous `Dockerfile` was `FROM nginx` + `COPY . /usr/share/nginx/html`, which served raw `src/`, `docs/`, `package*.json`, `*.psd` design files, etc. to the public web root — and was also broken, since it served un-built ES modules.

**Change:** converted to a multi-stage build.
- Stage 1 (`node:20-alpine`): `npm ci && npm run build`.
- Stage 2 (`nginx:alpine`): `COPY --from=build /app/dist /usr/share/nginx/html` — only the Vite build output (Vite `outDir` is `dist`, confirmed in `vite.config.js`).
- Added `.dockerignore` excluding `node_modules`, `.git`, `docs`, `test`, `*.psd`/`*.ai`, env files, and the Docker files themselves to keep the build context minimal.

### 2. [INFO] Debug `window.*` assignments in `src/bootstrap.js`

Removed the debug-only global assignments (`window.game`, `window.welcome_scene`, etc.). They are referenced nowhere else in `src/`, `test/`, or `index.html` (verified by grep); `kick_off()` runs on the local `game` const, so removal is safe. No security impact — this is cleanup, included since it was low-risk.

## Verification

`npm run build` (output dir is `dist/`):
```
> vite build
vite v6.4.2 building for production...
✓ 35 modules transformed.
dist/index.html                   1.66 kB │ gzip:  0.67 kB
dist/assets/tanks-DP0YTXMF.png   14.36 kB
dist/assets/index-BON_680t.js   136.66 kB │ gzip: 29.98 kB
✓ built in 155ms
```

`npm test`: **121/121 passing** (11 files).

`docker build` succeeds, and the resulting nginx web root contains only built assets (no source/docs/psd):
```
/usr/share/nginx/html:
50x.html  assets  data  favicon.ico  index.html  vendor
/usr/share/nginx/html/assets:
index-BON_680t.js  tanks-DP0YTXMF.png
```
(`50x.html` is nginx's own default error page from the base image.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)